### PR TITLE
Add ToStirng override to CorrelatedLogScope

### DIFF
--- a/src/Correlate.Core/Extensions/LoggerExtensions.cs
+++ b/src/Correlate.Core/Extensions/LoggerExtensions.cs
@@ -49,5 +49,14 @@ internal static class LoggerExtensions
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
+
+        /// <summary>
+        /// Returns a representation of the scope items as a list of comma-separated items,
+        /// matching the default representation provided by the standard Console logger.
+        /// </summary>
+        public override string ToString()
+        {
+            return string.Join(", ", this.Select(kv => $"{kv.Key}:{kv.Value}"));
+        }
     }
 }


### PR DESCRIPTION
Output to the default Console logger uses `ToString` on scope items. Without the override, the default output of the correlated scope is
```
...
 => Correlate.Extensions.LoggerExtensions+CorrelatedLogScope
...
```
when the output should be 
```
 => CorrelationId:8157ca4b-38e2-4748-b9aa-df5b2c4d4340
```

The proposed override formats the output in a similar way to the Console logger.